### PR TITLE
Add monthly averages to weather widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ClearSkyChart
 
-This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. It now displays daily metrics for the last week as well as averages for 7, 14 and 28 day periods. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
+This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. It now displays daily metrics for the last week, averages for 7, 14 and 28 day periods, and monthly averages for the last 12 months. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
 
 ## Usage
 
-1. Open `widget/index.html` in a browser. The script will request hourly data from the Open-Meteo API and display two tables: daily averages for the past 7 days and overall averages for 7, 14 and 28 day periods.
+1. Open `widget/index.html` in a browser. The script will request hourly data from the Open-Meteo API and display three tables: daily averages for the past 7 days, overall averages for 7, 14 and 28 day periods, and monthly averages for the last 12 months.
 2. To embed the widget in another page, copy the file or include it with an `<iframe>`:
    ```html
    <iframe src="/path/to/widget/index.html" style="border:0;width:660px;height:600px"></iframe>

--- a/widget/index.html
+++ b/widget/index.html
@@ -52,11 +52,26 @@
     </thead>
     <tbody></tbody>
   </table>
+  <h3>Monthly Averages (last 12 months)</h3>
+  <table id="monthly-table" style="display:none">
+    <thead>
+      <tr>
+        <th>Month</th>
+        <th>Avg Temp °C</th>
+        <th>Avg Humidity %</th>
+        <th>Avg Cloud %</th>
+        <th>Avg Wind m/s</th>
+        <th>Darkness %</th>
+        <th>Clear Sky Index</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
 </div>
 <script>
 const lat = -32.4;
 const lon = 20.7;
-const days = 28;
+const days = 365;
 
 async function loadWeather() {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
@@ -130,6 +145,35 @@ function dailyMetrics(days, stats) {
   });
 }
 
+function monthlyMetrics(days, stats) {
+  const months = {};
+  days.forEach(d => {
+    const m = d.slice(0, 7); // YYYY-MM
+    if (!months[m]) {
+      months[m] = {count:0, temp:0, hum:0, cloud:0, wind:0, nightHours:0};
+    }
+    const s = stats[d];
+    months[m].count += s.count;
+    months[m].temp += s.temp;
+    months[m].hum += s.hum;
+    months[m].cloud += s.cloud;
+    months[m].wind += s.wind;
+    months[m].nightHours += s.nightHours;
+  });
+  return Object.keys(months).sort().slice(-12).map(m => {
+    const s = months[m];
+    return {
+      month: m,
+      temp: s.temp / s.count,
+      hum: s.hum / s.count,
+      cloud: s.cloud / s.count,
+      wind: s.wind / s.count,
+      darkness: 100 * s.nightHours / s.count,
+      clearIndex: 100 - (s.cloud / s.count)
+    };
+  });
+}
+
 function renderReport(report) {
   const days = report.days;
   const stats = report.stats;
@@ -165,9 +209,26 @@ function renderReport(report) {
     `;
     tbody.appendChild(tr);
   });
+
+  const monthlyBody = document.querySelector('#monthly-table tbody');
+  monthlyBody.innerHTML = '';
+  monthlyMetrics(days, stats).forEach(m => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${m.month}</td>
+      <td>${m.temp.toFixed(1)}</td>
+      <td>${m.hum.toFixed(1)}</td>
+      <td>${m.cloud.toFixed(1)}</td>
+      <td>${m.wind.toFixed(1)}</td>
+      <td>${m.darkness.toFixed(1)}</td>
+      <td>${m.clearIndex.toFixed(1)}</td>
+    `;
+    monthlyBody.appendChild(tr);
+  });
   document.getElementById('status').style.display = 'none';
   document.getElementById('daily-table').style.display = '';
   document.getElementById('summary-table').style.display = '';
+  document.getElementById('monthly-table').style.display = '';
 }
 
 loadWeather();


### PR DESCRIPTION
## Summary
- fetch 365 days of data and compute monthly averages
- show the last 12 months in a new table
- document the new behaviour in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6877a257a14c832ca0533107b7428013