### PR TITLE
Persist monthly averages, limit fetch to 92 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ClearSkyChart
 
-This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. It now displays daily metrics for the last week, averages for 7, 14 and 28 day periods, and monthly averages for the last 12 months. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
+This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. Because the service only provides roughly three months of historical hourly data, the widget requests the most recent 92 days and persists computed monthly averages in the browser. It displays daily metrics for the last week, 7/14/28‑day averages, and monthly averages for up to the last year. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
 
 ## Usage
 
-1. Open `widget/index.html` in a browser. The script will request hourly data from the Open-Meteo API and display three tables: daily averages for the past 7 days, overall averages for 7, 14 and 28 day periods, and monthly averages for the last 12 months.
+1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of hourly data from the Open-Meteo API and displays three tables: daily averages for the past 7 days, overall averages for 7, 14 and 28 day periods, and monthly averages based on stored history (up to the last 12 months will be shown).
 2. To embed the widget in another page, copy the file or include it with an `<iframe>`:
    ```html
    <iframe src="/path/to/widget/index.html" style="border:0;width:660px;height:600px"></iframe>

--- a/widget/index.html
+++ b/widget/index.html
@@ -71,7 +71,33 @@
 <script>
 const lat = -32.4;
 const lon = 20.7;
-const days = 365;
+// Open-Meteo only allows ~92 days of historical hourly data
+// so we request the last 3 months and persist monthly averages
+const days = 92;
+
+const storageKey = 'csc-monthly';
+
+function loadStoredMonthly() {
+  try {
+    return JSON.parse(localStorage.getItem(storageKey)) || {};
+  } catch {
+    return {};
+  }
+}
+
+function saveStoredMonthly(data) {
+  localStorage.setItem(storageKey, JSON.stringify(data));
+}
+
+function mergeMonthly(stored, fresh) {
+  fresh.forEach(m => { stored[m.month] = m; });
+  // keep at most 24 months of history
+  const months = Object.keys(stored).sort();
+  const keep = months.slice(-24);
+  const trimmed = {};
+  keep.forEach(k => { trimmed[k] = stored[k]; });
+  return trimmed;
+}
 
 async function loadWeather() {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
@@ -213,16 +239,20 @@ function renderReport(report) {
 
   const monthlyBody = document.querySelector('#monthly-table tbody');
   monthlyBody.innerHTML = '';
-  monthlyMetrics(days, stats).forEach(m => {
+  const stored = loadStoredMonthly();
+  const updated = mergeMonthly(stored, monthlyMetrics(days, stats));
+  saveStoredMonthly(updated);
+  Object.keys(updated).sort().slice(-12).forEach(m => {
+    const val = updated[m];
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${m.month}</td>
-      <td>${m.temp.toFixed(1)}</td>
-      <td>${m.hum.toFixed(1)}</td>
-      <td>${m.cloud.toFixed(1)}</td>
-      <td>${m.wind.toFixed(1)}</td>
-      <td>${m.darkness.toFixed(1)}</td>
-      <td>${m.clearIndex.toFixed(1)}</td>
+      <td>${m}</td>
+      <td>${val.temp.toFixed(1)}</td>
+      <td>${val.hum.toFixed(1)}</td>
+      <td>${val.cloud.toFixed(1)}</td>
+      <td>${val.wind.toFixed(1)}</td>
+      <td>${val.darkness.toFixed(1)}</td>
+      <td>${val.clearIndex.toFixed(1)}</td>
     `;
     monthlyBody.appendChild(tr);
   });


### PR DESCRIPTION
## Summary
- limit Open-Meteo request to the last 92 days
- store monthly averages in `localStorage`
- show stored monthly averages when rendering
- document the 92‑day limitation and local storage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877a5bde0b8832cb679b1d728c30c99