### PR TITLE
Fix daily metrics date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ClearSkyChart
 
-This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. Because the service only provides roughly three months of historical hourly data, the widget requests the most recent 92 days of history and seven days of forecast data. It persists computed monthly averages in the browser. The page now shows a forecast for the next week, daily metrics for the previous week, 7/14/28‑day averages, and monthly averages for up to the last year. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
+This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. Because the service only provides roughly three months of historical hourly data, the widget requests the most recent 92 days of history and seven days of forecast data. It persists computed monthly averages in the browser. The page now shows a forecast for the next week (starting today), daily metrics for the previous week, 7/14/28‑day averages, and monthly averages for up to the last year. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
 
 ## Usage
 
-1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of historical data along with a 7‑day forecast from the Open-Meteo API. It displays four tables: a forecast for the next week, daily averages for the past week, overall averages for 7, 14 and 28 day periods, and monthly averages based on stored history (up to the last 12 months will be shown).
+1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of historical data along with a 7‑day forecast from the Open-Meteo API. It displays four tables: a forecast for the next week, daily averages for the past week (yesterday back seven days), overall averages for 7, 14 and 28 day periods, and monthly averages based on stored history (up to the last 12 months will be shown).
 2. To embed the widget in another page, copy the file or include it with an `<iframe>`:
    ```html
    <iframe src="/path/to/widget/index.html" style="border:0;width:660px;height:600px"></iframe>

--- a/widget/index.html
+++ b/widget/index.html
@@ -181,7 +181,8 @@ function averageMetrics(dayRange, days, stats) {
 }
 
 function dailyMetrics(days, stats) {
-  return days.slice(-7).reverse().map(d => {
+  const today = new Date().toISOString().slice(0,10);
+  return days.filter(d => d < today).slice(-7).reverse().map(d => {
     const s = stats[d];
     return {
       date: d,


### PR DESCRIPTION
## Summary
- exclude today from daily metrics to show data from yesterday back one week
- clarify date ranges in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a0566ed24832c822f3056ac29c5ce