### PR TITLE
Improve widget mobile layout

### DIFF
--- a/widget/index.html
+++ b/widget/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sutherland Clear Sky Widget</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,10 +13,15 @@
             border:1px solid #ddd; box-shadow:0 2px 5px rgba(0,0,0,0.1); }
   h2 { text-align:center; font-weight:400; }
   h3 { margin-top:2em; }
-  table { width:100%; border-collapse: collapse; margin-top: 1em; }
+  .table-wrap { overflow-x:auto; }
+  table { width:100%; border-collapse: collapse; margin-top: 1em; min-width:600px; }
   th, td { border: 1px solid #ccc; padding: 6px 8px; text-align:center; }
   th { background: #0077b6; color:white; }
   tbody tr:nth-child(even) { background:#f2f2f2; }
+  @media (max-width: 600px) {
+    th, td { padding:4px 6px; font-size: 14px; }
+    h3 { margin-top:1.5em; }
+  }
 </style>
 </head>
 <body>
@@ -23,6 +29,7 @@
   <h2>Clear Sky Report for Sutherland, South Africa</h2>
   <div id="status">Loading data...</div>
   <h3>Forecast (next 7 days)</h3>
+  <div class="table-wrap">
   <table id="forecast-table" style="display:none">
     <thead>
       <tr>
@@ -37,7 +44,9 @@
     </thead>
     <tbody></tbody>
   </table>
+  </div>
   <h3>Daily Metrics (last 7 days)</h3>
+  <div class="table-wrap">
   <table id="daily-table" style="display:none">
     <thead>
       <tr>
@@ -52,7 +61,9 @@
     </thead>
     <tbody></tbody>
   </table>
+  </div>
   <h3>7/14/28 Day Averages</h3>
+  <div class="table-wrap">
   <table id="summary-table" style="display:none">
     <thead>
       <tr>
@@ -67,7 +78,9 @@
     </thead>
     <tbody></tbody>
   </table>
+  </div>
   <h3>Monthly Averages (last 12 months)</h3>
+  <div class="table-wrap">
   <table id="monthly-table" style="display:none">
     <thead>
       <tr>
@@ -82,6 +95,7 @@
     </thead>
     <tbody></tbody>
   </table>
+  </div>
 </div>
 <script>
 const lat = -32.4;


### PR DESCRIPTION
## Summary
- add viewport meta tag
- allow horizontal scrolling of tables and adjust padding
- wrap data tables in divs with `overflow-x: auto`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a16828d64832c8b464a5a312db707