### PR TITLE
Ignore incomplete months in ClearSkyChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ClearSkyChart
 
-This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. Because the service only provides roughly three months of historical hourly data, the widget requests the most recent 92 days of history and seven days of forecast data. It persists computed monthly averages in the browser. The page now shows a forecast for the next week (starting today), daily metrics for the previous week, 7/14/28‑day averages, and monthly averages for up to the last year. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
+This repository contains a simple web widget that fetches weather data for **Sutherland, South Africa** using the [Open-Meteo](https://open-meteo.com/) API. Because the service only provides roughly three months of historical hourly data, the widget requests the most recent 92 days of history and seven days of forecast data. It persists computed monthly averages in the browser. The page now shows a forecast for the next week (starting today), daily metrics for the previous week, 7/14/28‑day averages, and monthly averages for up to the last year. The monthly table only displays months that have a full set of hourly data. Each month's entry records the number of hours aggregated so incomplete months can be ignored on subsequent loads. The widget is implemented in `widget/index.html` and can be embedded in any webpage.
 
 ## Usage
 
-1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of historical data along with a 7‑day forecast from the Open-Meteo API. It displays four tables: a forecast for the next week, daily averages for the past week (yesterday back seven days), overall averages for 7, 14 and 28 day periods, and monthly averages based on stored history (up to the last 12 months will be shown).
+1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of historical data along with a 7‑day forecast from the Open-Meteo API. It displays four tables: a forecast for the next week, daily averages for the past week (yesterday back seven days), overall averages for 7, 14 and 28 day periods, and monthly averages based on stored history (up to the last 12 months will be shown and only completed months are displayed).
 2. To embed the widget in another page, copy the file or include it with an `<iframe>`:
    ```html
    <iframe src="/path/to/widget/index.html" style="border:0;width:660px;height:600px"></iframe>

--- a/widget/index.html
+++ b/widget/index.html
@@ -143,6 +143,11 @@ function formatHours(hours) {
   return `${h}h${m}`;
 }
 
+function daysInMonth(ym) {
+  const [y, m] = ym.split('-').map(Number);
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
 function loadStoredMonthly() {
   try {
     return JSON.parse(localStorage.getItem(storageKey)) || {};
@@ -156,12 +161,18 @@ function saveStoredMonthly(data) {
 }
 
 function mergeMonthly(stored, fresh) {
+  // integrate new monthly data and discard incomplete months
   fresh.forEach(m => { stored[m.month] = m; });
-  // keep at most 24 months of history
-  const months = Object.keys(stored).sort();
-  const keep = months.slice(-24);
   const trimmed = {};
-  keep.forEach(k => { trimmed[k] = stored[k]; });
+  Object.keys(stored)
+    .sort()
+    .slice(-24)
+    .forEach(k => {
+      const val = stored[k];
+      if (val.hours === undefined || val.hours >= daysInMonth(k) * 24) {
+        trimmed[k] = val;
+      }
+    });
   return trimmed;
 }
 
@@ -263,8 +274,9 @@ function forecastMetrics(days, stats) {
 }
 
 function monthlyMetrics(days, stats) {
+  const today = new Date().toISOString().slice(0, 10);
   const months = {};
-  days.forEach(d => {
+  days.filter(d => d < today).forEach(d => {
     const m = d.slice(0, 7); // YYYY-MM
     if (!months[m]) {
       months[m] = {count:0, temp:0, hum:0, cloud:0, wind:0, nightHours:0};
@@ -277,18 +289,23 @@ function monthlyMetrics(days, stats) {
     months[m].wind += s.wind;
     months[m].nightHours += s.nightHours;
   });
-  return Object.keys(months).sort().slice(-12).map(m => {
-    const s = months[m];
-    return {
-      month: m,
-      temp: s.temp / s.count,
-      hum: s.hum / s.count,
-      cloud: s.cloud / s.count,
-      wind: s.wind / s.count,
-      darkHours: s.nightHours / (s.count / 24),
-      clearIndex: 100 - (s.cloud / s.count)
-    };
-  });
+  return Object.keys(months)
+    .sort()
+    .filter(m => months[m].count >= daysInMonth(m) * 24)
+    .slice(-12)
+    .map(m => {
+      const s = months[m];
+      return {
+        month: m,
+        hours: s.count,
+        temp: s.temp / s.count,
+        hum: s.hum / s.count,
+        cloud: s.cloud / s.count,
+        wind: s.wind / s.count,
+        darkHours: s.nightHours / (s.count / 24),
+        clearIndex: 100 - (s.cloud / s.count)
+      };
+    });
 }
 
 function renderReport(report) {


### PR DESCRIPTION
## Summary
- filter out incomplete months when merging stored data
- keep track of month hours and persist them
- clarify full month requirement in README
- update comment for merge logic

## Testing
- `git diff --stat`
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687a19b91838832cad3289ce7e102f50