### PR TITLE
Add weather proxy and update widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repository contains a simple web widget that fetches weather data for **Sut
 
 The code does not require any build step and only relies on the browser's fetch API. Internet access is required at runtime to retrieve data from Open-Meteo.
 
+When deploying the widget, make sure your site is served over **HTTPS** and use
+the provided `weather.php` proxy to forward requests to the Open‑Meteo service.
+Fetching weather data through this proxy avoids CORS problems and can reduce the
+chance of hitting IP based rate limits.
+
 ## Troubleshooting
 
 If the widget displays **"Failed to load data"**, ensure that your network

--- a/weather.php
+++ b/weather.php
@@ -1,0 +1,20 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json");
+
+$url = "https://api.open-meteo.com/v1/forecast?latitude=-32.4&longitude=20.7&hourly=temperature_2m,relativehumidity_2m,cloudcover,windspeed_10m,is_day&past_days=92&forecast_days=7&timezone=UTC";
+
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_USERAGENT, 'ClearSkyChart/1.0');
+$result = curl_exec($ch);
+$err = curl_error($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+if ($result === false || $code >= 400) {
+    http_response_code(502);
+    echo json_encode(["error" => $err ?: "Failed to fetch data", "status" => $code]);
+} else {
+    echo $result;
+}
+?>

--- a/widget/index.html
+++ b/widget/index.html
@@ -126,9 +126,7 @@ function formatHours(hours) {
 
 
 async function loadWeather() {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
-              `&hourly=temperature_2m,relativehumidity_2m,cloudcover,windspeed_10m,is_day` +
-              `&past_days=${days}&forecast_days=7&timezone=UTC`;
+  const url = '/weather.php';
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Network response was not ok');
@@ -138,7 +136,8 @@ async function loadWeather() {
   } catch (err) {
     const msg = 'Failed to load data: ' + (err.message || err);
     document.getElementById('status').textContent = msg;
-    console.error(err);
+    console.error('Error loading weather data:', err);
+    console.log('API URL:', url);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a `weather.php` proxy that requests data from Open‑Meteo
- fetch from the proxy in `widget/index.html`
- log errors and URL in case of failure
- mention HTTPS deployment and proxy usage in the README

## Testing
- `php -l weather.php`

------
https://chatgpt.com/codex/tasks/task_e_687df50ed454832cbdf9b7d3ffc1e25a