### PR TITLE
Add WordPress plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ the provided `weather.php` proxy to forward requests to the Open‑Meteo service
 Fetching weather data through this proxy avoids CORS problems and can reduce the
 chance of hitting IP based rate limits.
 
+
+## WordPress Plugin
+
+This repository can be installed as a WordPress plugin. Upload the entire directory to your site's `wp-content/plugins` folder and activate **Clear Sky Chart** from the admin Plugins page. Use the `[clearskychart]` shortcode in a post or page to embed the widget.
 ## Troubleshooting
 
 If the widget displays **"Failed to load data"**, ensure that your network
@@ -24,6 +28,7 @@ allows connections to `api.open-meteo.com`. Some environments block external
 requests, which will prevent the data from loading.
 
 ## Example: Requesting Current Weather
+
 
 When using `current_weather=true` with the Open‑Meteo API you must also request
 at least one weather variable. Otherwise the service returns `400 Bad Request`.

--- a/clearskychart.php
+++ b/clearskychart.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: Clear Sky Chart
+Description: Displays a clear sky weather widget for Sutherland, South Africa using the Open-Meteo API.
+Version: 1.0.0
+Author: Clear Sky Contributors
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+function clearskychart_shortcode() {
+    $src = plugins_url('widget/index.html', __FILE__);
+    return '<iframe src="' . esc_url($src) . '" style="border:0;width:660px;height:600px"></iframe>';
+}
+add_shortcode('clearskychart', 'clearskychart_shortcode');
+?>

--- a/widget/index.html
+++ b/widget/index.html
@@ -126,7 +126,7 @@ function formatHours(hours) {
 
 
 async function loadWeather() {
-  const url = '/weather.php';
+  const url = "../weather.php";
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Network response was not ok');


### PR DESCRIPTION
## Summary
- create `clearskychart.php` shortcode plugin
- allow widget to fetch weather data relative to plugin path
- document how to use the plugin in README

## Testing
- `php -l clearskychart.php`
- `php -l weather.php`


------
https://chatgpt.com/codex/tasks/task_e_687e00d9a8f0832cb1149fbf0aa85d10