### PR TITLE
Improve mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a simple web widget that fetches weather data for **Sut
 1. Open `widget/index.html` in a browser. The script requests the most recent 92 days of historical data along with a 7‑day forecast from the Open-Meteo API. It displays three tables: a forecast for the next week, daily averages for the past week (yesterday back seven days), and overall averages for 7, 14, 28 and 90 day periods.
 2. To embed the widget in another page, copy the file or include it with an `<iframe>`:
    ```html
-   <iframe src="/path/to/widget/index.html" style="border:0;width:660px;height:600px"></iframe>
+   <iframe src="/path/to/widget/index.html" style="border:0;width:100%;height:600px;z-index:1;position:relative"></iframe>
    ```
 
 The code does not require any build step and only relies on the browser's fetch API. Internet access is required at runtime to retrieve data from Open-Meteo.

--- a/clearskychart.php
+++ b/clearskychart.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
 
 function clearskychart_shortcode() {
     $src = plugins_url('widget/index.html', __FILE__);
-    return '<iframe src="' . esc_url($src) . '" style="border:0;width:660px;height:600px"></iframe>';
+    return '<iframe src="' . esc_url($src) . '" style="border:0;width:100%;height:600px;z-index:1;position:relative"></iframe>';
 }
 add_shortcode('clearskychart', 'clearskychart_shortcode');
 ?>

--- a/widget/index.html
+++ b/widget/index.html
@@ -9,8 +9,18 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
 <style>
   body { font-family: 'Roboto', sans-serif; background:#f9f9f9; color:#333; }
-  #widget { max-width: 650px; margin: auto; background:white; padding:1em; border-radius:8px;
-            border:1px solid #ddd; box-shadow:0 2px 5px rgba(0,0,0,0.1); }
+  #widget {
+    width: 100%;
+    max-width: 650px;
+    margin: auto;
+    background: white;
+    padding: 1em;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    position: relative;
+    z-index: 1;
+  }
   h2 { text-align:center; font-weight:400; }
   h3 { margin-top:2em; }
   .table-wrap { overflow-x:auto; }


### PR DESCRIPTION
## Summary
- let the weather widget fill the available width
- add z-index styling and remove fixed sizing on the WordPress plugin
- document how to embed the widget responsively

## Testing
- `php -l clearskychart.php`
- `php -l weather.php`
- `htmlhint widget/index.html`
- `node examples/fetch-current-weather.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6887624648f0832c83acc0dbf26ac2d4